### PR TITLE
Making axes centered

### DIFF
--- a/src/styles/_cycle7-theme.scss
+++ b/src/styles/_cycle7-theme.scss
@@ -33,7 +33,7 @@ h4 {
   text-align: center;
 
   &__map {
-    padding: 1.75rem;
+    padding: 1.75rem 1.75rem 1.75rem 3rem;
     background: #f7f7f7;
 
     .c7-assumptions-map {


### PR DESCRIPTION
Vertical axis was a bit off compared to the arrows below. Added padding to fix it.