### PR TITLE
feat(tracking): add Google Tag Manager plugin and element visibility tracking

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -15,6 +15,20 @@ module.exports = {
       },
     },
     `gatsby-transformer-remark`,
+    {
+      resolve: "gatsby-plugin-google-tagmanager",
+      options: {
+        id: "GTM-T4M7Q68",
+
+        // Include GTM in development.
+        // Defaults to false meaning GTM will only be loaded in production.
+        includeInDevelopment: false,
+
+        // Specify optional GTM environment details.
+        gtmAuth: "asSE5ymiFEeLCYtPpk60Ig",
+        gtmPreview: "env-2",
+      },
+    },
     `gatsby-plugin-react-helmet`,
     {
       resolve: `gatsby-source-filesystem`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7635,6 +7635,26 @@
         "slash": "^3.0.0"
       }
     },
+    "gatsby-plugin-google-tagmanager": {
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-tagmanager/-/gatsby-plugin-google-tagmanager-2.1.12.tgz",
+      "integrity": "sha512-cTW5d+QBrQWgX1aEJ1EJo/ecNkq3xmVr5Wkau/GyQ3ZQcFZYbuwa+8rbe5N+JD90y4Jpg6aCkLztoHmBLMHskw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.6.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+          "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
+      }
+    },
     "gatsby-plugin-manifest": {
       "version": "2.2.16",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.2.16.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "eyeglass": "^2.4.1",
+    "gatsby-plugin-google-tagmanager": "^2.1.12",
     "prettier": "^1.17.0"
   },
   "keywords": [

--- a/src/components/contact.js
+++ b/src/components/contact.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 const Contact = () => (
-  <div className="contact">
+  <div className="contact" data-gtm-track="contact-form">
     <section className="grav-o-full-bleed__content grav-u-pt-xxl grav-u-pb-xxl">
       <h2 className="grav-u-text-centered">Let's talk</h2>
       <div className="row">

--- a/src/components/outcomes.js
+++ b/src/components/outcomes.js
@@ -2,7 +2,7 @@ import React from "react";
 import Tick from "../images/tick.svg"
 
 const Outcomes = () => (
-  <section className="grav-o-full-bleed__content grav-u-pt-xxl grav-u-pb-xxl">
+   <section className="grav-o-full-bleed__content grav-u-pt-xxl grav-u-pb-xxl" data-gtm-track="outcomes">
     <p className="lead-text">
       Standalone, or within a programme, Cycle 7 de-risks any given proposition and exposes the answers stakeholders need to know. Fast.
     </p>

--- a/src/components/phases.js
+++ b/src/components/phases.js
@@ -10,7 +10,7 @@ const Phases = () => (
       How our process works
     </h2>
     <div>
-      <div className="c7-phase grav-u-pb-xl">
+      <div className="c7-phase grav-u-pb-xl" data-gtm-track="phase-1">
         <div className="phase-heading">
           <div className="grav-o-full-bleed__content">
             <div className="row phase-heading-content phase-heading-content--bulb">
@@ -77,7 +77,7 @@ const Phases = () => (
           </div>
         </div>
       </div>
-      <div className="c7-phase grav-u-pb-xl">
+      <div className="c7-phase grav-u-pb-xl" data-gtm-track="phase-2">
         <div className="phase-heading">
           <div className="grav-o-full-bleed__content">
             <div className="row phase-heading-content phase-heading-content--test">
@@ -121,7 +121,7 @@ const Phases = () => (
           </div>
         </div>
       </div>
-      <div className="c7-phase grav-u-pb-xl">
+      <div className="c7-phase grav-u-pb-xl" data-gtm-track="phase-3">
         <div className="phase-heading">
           <div className="grav-o-full-bleed__content">
             <div className="row phase-heading-content phase-heading-content--sign">

--- a/src/components/strategy.js
+++ b/src/components/strategy.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 const Strategy = () => (
-  <section className="strategy">
+  <section className="strategy" data-gtm-track="discover-and-deliver">
     <div className="grav-o-full-bleed__content grav-u-pt-xxl grav-u-pb-xxl">
       <div className="grav-u-text-centered">
         <h3>Discover and Deliver</h3>

--- a/src/components/team.js
+++ b/src/components/team.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 const Team = () => (
-  <section className="grav-o-full-bleed__content grav-u-pt-xxl">
+  <section className="grav-o-full-bleed__content grav-u-pt-xxl" data-gtm-track="collaboration">
     <h3 className="grav-u-text-centered grav-u-font-size-plus-4">
       Better Together
     </h3>


### PR DESCRIPTION
Adds GTM code in the form of a gatsby plugin.

Tracks two things:

1. Page View event on the `gatsby-route-change` event
2. Element Visibility tracking on sections within the main cycle 7 homepage

You can track more elements in the future by adding an attribute of `data-gtm-track="section-name-here"`.